### PR TITLE
fix: strip origin/ prefix from git branch completions

### DIFF
--- a/powershell/GitCompleter/GitCompleter.psm1
+++ b/powershell/GitCompleter/GitCompleter.psm1
@@ -12,8 +12,10 @@ function Get-GitRemoteBranch {
     $branches = git for-each-ref --format="%(refname:short)" refs/remotes/ 2>$null
     if ($LASTEXITCODE -ne 0) { return @() }
     @($branches) |
-        Where-Object { -not $_.EndsWith("/HEAD") -and $_ -like "$Filter*" } |
-        Sort-Object
+        Where-Object { $_ -ne "origin" -and -not $_.EndsWith("/HEAD") } |
+        ForEach-Object { $_ -replace "^origin/", "" } |
+        Where-Object { $_ -like "$Filter*" } |
+        Sort-Object -Unique
 }
 
 function Get-GitTag {
@@ -204,6 +206,7 @@ function Register-GitCompleter {
             $results += Get-GitLocalBranch  -Filter $wordToComplete
             $results += Get-GitRemoteBranch -Filter $wordToComplete
             $results += Get-GitTag          -Filter $wordToComplete
+            $results = $results | Sort-Object -Unique
         }
 
         $results | ForEach-Object {


### PR DESCRIPTION
## Summary

`git checkout`/`switch` tab-completion listed remote branches with their full `origin/<name>` path,
so completing `main` offered `origin/main` — which is awkward to use for the common DWIM checkout.

- `Get-GitRemoteBranch` now strips an anchored `^origin/` prefix (origin only — other remotes keep
  their `<remote>/<name>` form), skips `*/HEAD` and a bare `origin` ref, and de-duplicates.
- `Register-GitCompleter` de-duplicates the combined local + remote + tag candidates so a local
  branch and the stripped remote branch of the same name are offered once.

## Testing

- Verified completion of a partial branch name now offers the bare `origin` branch name, while a
  second remote's branches keep their `<remote>/<name>` prefix.
- Confirmed local/remote name collisions are offered once.

Closes #62
