### PR TITLE
fix: remove duplicate inline diagnostics

### DIFF
--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -3028,7 +3028,7 @@ addPlugin {
 			},
 			transparent_bg = false
 		})
-		vim.diagnostic.config({ virtual_text = true })
+		vim.diagnostic.config({ virtual_text = false })
 		diag.enable()
 	end,
 }


### PR DESCRIPTION
## Summary

Diagnostics were rendered twice inline: once by the `tiny-inline-diagnostic` plugin and once by
Neovim's native diagnostic virtual text, which the config re-enabled with
`vim.diagnostic.config({ virtual_text = true })` right after the plugin setup.

Set native `virtual_text = false` so `tiny-inline-diagnostic` is the sole inline renderer.

## Testing

- Opened a buffer with LSP diagnostics and confirmed each diagnostic now shows once (plugin render
  only), with signs still present.

Closes #40
