### PR TITLE
fix: defer mason auto-install FileType replay until augroup exists

### DIFF
--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -2967,7 +2967,20 @@ addPlugin {
 	"owallb/mason-auto-install.nvim",
 	config = function(_, cfg)
 		require("mason-auto-install").setup(cfg)
-		vim.api.nvim_exec_autocmds("FileType", { group = "MasonAutoInstall", pattern = vim.o.filetype })
+
+		local group = "MasonAutoInstall"
+		local retries_remaining = 50
+		local function trigger_current_filetype()
+			local ok = pcall(vim.api.nvim_get_autocmds, { group = group })
+			if ok then
+				vim.api.nvim_exec_autocmds("FileType", { group = group, pattern = vim.o.filetype })
+			elseif retries_remaining > 0 then
+				retries_remaining = retries_remaining - 1
+				vim.defer_fn(trigger_current_filetype, 100)
+			end
+		end
+
+		trigger_current_filetype()
 	end,
 	opts = {
 		packages = {


### PR DESCRIPTION
## Summary

`mason-auto-install.nvim` creates its `MasonAutoInstall` augroup asynchronously (inside a
`registry.refresh` callback), but the config fired `nvim_exec_autocmds("FileType", { group =
"MasonAutoInstall" })` immediately after `setup()`, before the augroup existed — raising
`Invalid 'group': 'MasonAutoInstall'` on startup.

Defer the grouped replay: `trigger_current_filetype()` probes for the augroup with
`pcall(nvim_get_autocmds, { group = ... })` and only fires the `FileType` autocmd once it exists,
otherwise re-schedules itself via `vim.defer_fn` with a finite 50-retry budget so startup can never
loop forever. The group filter is preserved so no unrelated handlers are replayed.

## Testing

- Headless reproduction (`nvim --headless`) previously raised `E5108: Invalid 'group'`; after the fix
  headless init exits cleanly with no error.

Closes #39
