### PR TITLE
fix: normalize lualine filename symbol spacing

### DIFF
--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -3783,8 +3783,8 @@ addPlugin {
 						symbols = {
 							modified = icons.file_modified,
 							readonly = icons.file_readonly,
-							unnamed  = " " .. icons.file_unnamed .. " ",
-							newfile  = " " .. icons.file_newfile .. " "
+							unnamed  = icons.file_unnamed,
+							newfile  = icons.file_newfile
 						}
 					}
 				},


### PR DESCRIPTION
## Summary

The lualine filename component padded the `unnamed` and `newfile` symbols with leading/trailing
spaces (`" " .. icon .. " "`), producing extra whitespace in the statusline compared with the other
filename states.

Use the bare icons so spacing matches the other symbols.

## Testing

- Opened an unnamed buffer and a new file; confirmed the filename segment spacing now matches named
  buffers with no extra padding.

Closes #50
