### PR TITLE
feat: render whatis function header as a pill badge

### DIFF
--- a/powershell/profile.ps1
+++ b/powershell/profile.ps1
@@ -410,7 +410,7 @@ function whatis($arg) {
     $type = $cm.CommandType
 
     if ($type -eq "Function") {
-        Format-Text "󰊕 $arg" -fg $catppuccin.Red -styles italic
+        Format-Pill "󰊕 $arg" -bg $catppuccin.Red -fg $catppuccin.Base -styles italic
         $temp_file = "$env:TEMP\tmp.ps1"
         Write-Output $cm.Definition > $temp_file
         D:\Scoop\shims\bat.exe -P --style="numbers,changes" --italic-text=always --theme $bat_theme $temp_file
@@ -601,6 +601,35 @@ function Format-Text {
     }
 
     return $head
+}
+
+function Format-Pill {
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [String]$text,
+
+        [Parameter(Mandatory)]
+        [String]$bg,
+
+        [Parameter(Mandatory)]
+        [String]$fg,
+
+        [ValidateSet("blink","bold","hidden","italic","reverse","strikethrough","underline")]
+        [Array]$styles
+    )
+
+    $left_cap = "`u{E0B6}"
+    $right_cap = "`u{E0B4}"
+
+    $pill = Format-Text $left_cap -fg $bg -noreset
+    if ($styles.Count -gt 0) {
+        $pill += Format-Text " $text " -fg $fg -bg $bg -styles $styles -noreset
+    } else {
+        $pill += Format-Text " $text " -fg $fg -bg $bg -noreset
+    }
+    $pill += Format-Text $right_cap -fg $bg
+
+    return $pill
 }
 
 # ╭───────────╮


### PR DESCRIPTION
## Summary

`whatis` rendered a function's header with plain italic text, inconsistent with the pill/badge styling
used elsewhere.

- Add a `Format-Pill` helper that wraps text in Powerline caps (`` `u{E0B6}`` / `` `u{E0B4}``) with a
  colored background, forwarding optional styles to `Format-Text`.
- Render the `whatis` function header via `Format-Pill` on the red background.

## Testing

- Ran `whatis <function>` and confirmed the header now renders as a red pill badge; non-function
  commands are unaffected.

Closes #60
