### PR TITLE
feat: install packages from github releases

### DIFF
--- a/autosetup.ps1
+++ b/autosetup.ps1
@@ -293,6 +293,85 @@ function wingetInstall {
     }
 }
 
+function githubInstall {
+    param(
+        [hashtable[]]$pkgs,
+        [switch]$update
+    )
+    if ($pkgs.Length -eq 0) {
+        return
+    }
+
+    $versionFile = "$env:XDG_STATE_HOME\autosetup\github-releases.json"
+    if (Test-Path $versionFile) {
+        $versions = Get-Content $versionFile -Raw | ConvertFrom-Json -AsHashtable
+    } else {
+        $versions = @{}
+    }
+
+    foreach ($pkg in $pkgs) {
+        $repo = $pkg.repo
+        $installed = $versions.ContainsKey($repo)
+
+        if (-not $installed -and $update) {
+            continue
+        }
+
+        $latestTag = gh release view --repo $repo --json tagName --jq ".tagName"
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($latestTag)) {
+            writeLog ERROR "Failed to resolve latest release tag: $repo"
+            continue
+        }
+        $latestTag = $latestTag.Trim()
+
+        if ($installed -and $versions[$repo] -eq $latestTag) {
+            writeLog INFO "GitHub release up to date: $repo ($latestTag)"
+            continue
+        }
+        if ($installed) {
+            writeLog UPDATE "Updating GitHub release: $repo -> $latestTag"
+        } else {
+            writeLog UPDATE "Installing GitHub release: $repo ($latestTag)"
+        }
+
+        if (-not (Test-Path $pkg.dir)) {
+            New-Item -ItemType Directory -Path $pkg.dir | Out-Null
+        }
+        $tmp = Join-Path $env:TEMP ([guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $tmp | Out-Null
+        try {
+            gh release download $latestTag --repo $repo --pattern $pkg.asset --dir $tmp
+            if ($LASTEXITCODE -ne 0) {
+                writeLog ERROR "Failed to download release asset: $repo ($($pkg.asset))"
+                continue
+            }
+            $downloaded = @(Get-ChildItem -File $tmp)
+            if ($downloaded.Count -ne 1) {
+                writeLog ERROR "Expected exactly one asset for $repo, got $($downloaded.Count)"
+                continue
+            }
+            $asset = $downloaded[0]
+            switch ($asset.Extension) {
+                ".zip" { Expand-Archive -Path $asset.FullName -DestinationPath $pkg.dir -Force }
+                ".exe" { Move-Item -Path $asset.FullName -Destination $pkg.dir -Force }
+                default {
+                    writeLog ERROR "Unsupported asset type for $repo`: $($asset.Name)"
+                    continue
+                }
+            }
+            $versions[$repo] = $latestTag
+        } finally {
+            Remove-Item -Recurse -Force $tmp
+        }
+    }
+
+    $stateDir = Split-Path $versionFile
+    if (-not (Test-Path $stateDir)) {
+        New-Item -ItemType Directory -Path $stateDir | Out-Null
+    }
+    $versions | ConvertTo-Json | Set-Content -Path $versionFile
+}
+
 function linkConfigs {
     param(
         [hashtable]$files
@@ -408,6 +487,7 @@ foreach ($pkg in $pkg_list) {
     $cwd = Get-Location
 
     if (Test-Path setup.ps1) {
+        $github_pkgs = @()
         $npm_pkgs = @()
         $pip_pkgs = @()
         $pipx_pkgs = @()
@@ -420,6 +500,7 @@ foreach ($pkg in $pkg_list) {
         . .\setup.ps1
 
         if ($update) {
+            githubInstall -update $github_pkgs
             npmInstall -update $npm_pkgs
             pipInstall -update $pip_pkgs
             pipxInstall -update $pipx_pkgs
@@ -428,6 +509,7 @@ foreach ($pkg in $pkg_list) {
             wingetInstall -update $winget_pkgs
             copyOrUpdateConfigs -update $files_copy
         } else {
+            githubInstall $github_pkgs
             npmInstall $npm_pkgs
             pipInstall $pip_pkgs
             pipxInstall $pipx_pkgs


### PR DESCRIPTION
# Summary

Adds a GitHub-releases package source to `autosetup.ps1`, following the existing
per-package-manager convention (`$<name>_pkgs` variable + `<name>Install` function). Windows-only,
using the `gh` CLI.

- New `githubInstall` function: `[hashtable[]]$pkgs` + `[switch]$update`, early-returns on empty
  input, 1TBS + double quotes.
- Packages are declared in a package's `setup.ps1` as an array of hashtables
  (`@{ repo = "owner/repo"; asset = "*glob*.zip"; dir = "..." }`).
- Version tracking via a central JSON map `owner/repo -> tag` at
  `$env:XDG_STATE_HOME\autosetup\github-releases.json`, loaded once and written back once per
  invocation.
- Latest tag resolved with `gh release view`; asset fetched with `gh release download --pattern`;
  `.zip` extracted (`-Force`) or `.exe` moved (`-Force`) into the target dir.
- Failure (tag lookup fails/empty, download fails, zero/multiple assets, unsupported extension)
  logs `ERROR` and does not record the tag; the temp download dir is always removed via `finally`.
- Wired `$github_pkgs = @()` into the per-package init block and `githubInstall` into the update and
  install branches (alphabetically, before `npm`).

Existing installers (scoop/winget/npm/pip/pipx/psgallery) and config linking are unchanged.

# Testing

The repo has no automated tests; `autosetup.ps1` also carries `#requires -RunAsAdministrator`, so the
new `githubInstall` function was exercised in isolation (extracted from source via AST) against a
real `gh`-authenticated session using `sharkdp/fd`:

| Scenario | Result |
|----------|--------|
| Fresh install | `fd.exe` extracted into dir; `github-releases.json` records `sharkdp/fd -> v10.5.0` |
| Re-install (tag == latest) | no-op, `INFO` "up to date", no download |
| `-update` matching tag | skipped |
| `-update` stale sentinel tag | re-downloaded and re-extracted |
| Fresh package under `-update` | skipped before any network call, map unchanged |
| Non-existent repo | `ERROR` logged, tag not recorded |
| Non-matching asset pattern | `ERROR` logged, tag not recorded |

Temp download dirs were cleaned up in every case (verified no leftover GUID dirs).

Closes #80
