### PR TITLE
fix: make csv devicon legible on latte theme

### DIFF
--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -2495,7 +2495,7 @@ addPlugin {
 				cpp      = { color = "#F34B7D", icon = "󰙲", name = "Cpp"       },
 				cs       = { color = "#C20DA6", icon = "󰌛", name = "Cs"        },
 				csproj   = { color = "#854CC7", icon = "", name = "Csproj"    },
-				csv      = { color = "#89E051", icon = "", name = "Csv"       },
+				csv      = { color = "#3A8A20", icon = "", name = "Csv"       },
 				md       = { color = "#42A5F5", icon = "", name = "Md"        },
 				mdx      = { color = "#519ABA", icon = "󰽛", name = "Mdx"       },
 				py       = { color = "#3D7BAB", icon = "", name = "Py"        },


### PR DESCRIPTION
## Summary

The csv filetype icon used `#89E051`, a saturated light green that is effectively invisible against
the catppuccin **latte** (light) background. This changes it to `#3A8A20`, which meets the WCAG 1.4.11
non-text 3:1 contrast minimum on both themes while keeping the icon green.

Measured WCAG contrast (via `tmp/repro-36.ps1`):

| color | vs latte (`#EFF1F5`) | vs mocha (`#1E1E2E`) |
|-------|-----------------------|------------------------|
| `#89E051` (before) | 1.45 ❌ | 10.03 |
| `#3A8A20` (after)  | 3.84 ✅ | 3.78 ✅ |

## Testing

- `nvim -l` compile-check of `neovim/init.lua` → SYNTAX OK.
- Contrast recomputed: latte 1.45 → 3.84 (clears 3:1), mocha 3.78 (still legible).
- Diff confirms only the csv override entry changed.

Closes #36
