### PR TITLE
fix: toggle scrollview via lua api on lualine click

### DIFF
--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -3838,7 +3838,7 @@ addPlugin {
 							return str:gsub("^%s+", ""):gsub("%s+", "")
 						end,
 						on_click = function ()
-							vim.cmd("ScrollViewToggle")
+							require("scrollview").set_state()
 						end,
 						padding = { left = 0, right = 0 },
 						separator = { left = "", right = "█" }


### PR DESCRIPTION
## Summary

The lualine `location` segment's `on_click` ran `vim.cmd("ScrollViewToggle")`, which failed with
`E492: Not an editor command: ScrollViewToggle`.

Root cause: `nvim-scrollview` is `cmd`-lazy loaded on `ScrollViewToggle`, so lazy.nvim registers a
stub command. The plugin defines its real commands at the top of `autoload/scrollview.vim`, each
guarded by `if !exists(':ScrollViewToggle')`, and that file is sourced only via a deferred
`timer_start(0)`. When the deferred registration runs, lazy's stub still exists, so the guard is false
and the real command is never defined; lazy then removes its stub, leaving no command. The first click
loads the plugin, but every subsequent click errors with E492.

Fix: call the plugin's stable public Lua API directly — `require("scrollview").set_state()` — which
lazy.nvim auto-loads on `require` and toggles reliably. This is exactly what `:ScrollViewToggle`
dispatches to (`set_state(v:null)`), so behavior is unchanged apart from removing the error.

## Testing

Verified headlessly against the real config, loading this branch's patched `init.lua` via a
`package.preload['init']` override (nvim's runtimepath loader otherwise wins over `package.path`):

- Invoked the **actual wired** lualine `location` `on_click`: 4 consecutive clicks toggle
  `true → false → true → false` with no error (previously the 2nd click onward raised E492).
- On a scrollable 500-line buffer: enabling creates the scrollview bar windows (4 floats), disabling
  removes them (0 floats) — the scrollbar shows/hides as expected.

## Notes

Issue line references had drifted; the actual handler is at `neovim/init.lua:3840-3842` and the plugin
block at `1212-1214`.

Closes #51
