### PR TITLE
fix: name anonymous namespaces in InspectExtmarks

### DIFF
--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -4404,7 +4404,51 @@ addPlugin {
 addPlugin {
 	"delphinus/inspect-extmarks.nvim",
 	cmd = "InspectExtmarks",
-	config = true
+	-- nvim_get_namespaces() omits anonymous namespaces, so the plugin resolves ns_name to nil for
+	-- them, crashing its sort (nil < nil) and its nvim_echo ({ nil, "Title" }). Name anonymous
+	-- namespaces on the cursor row for the duration of one inspect() call. Revisit if upstream fixes.
+	config = function()
+		local ext = require("inspect-extmarks")
+		ext.setup()
+		local orig_inspect = ext.inspect
+		ext.inspect = function(opts)
+			local orig_get_ns = vim.api.nvim_get_namespaces
+			vim.api.nvim_get_namespaces = function()
+				local named = orig_get_ns()
+				local known = {}
+				for _, id in pairs(named) do
+					known[id] = true
+				end
+				local ok, marks = pcall(
+					vim.api.nvim_buf_get_extmarks,
+					opts.bufnr,
+					-1,
+					{ opts.row, 0 },
+					{ opts.row + 1, 0 },
+					{ details = true }
+				)
+				if ok then
+					for _, m in ipairs(marks) do
+						local nsid = m[4] and m[4].ns_id
+						if nsid and not known[nsid] then
+							local name = ("<anonymous %d>"):format(nsid)
+							while named[name] and named[name] ~= nsid do
+								name = name .. "#"
+							end
+							named[name] = nsid
+							known[nsid] = true
+						end
+					end
+				end
+				return named
+			end
+			local ok, err = pcall(orig_inspect, opts)
+			vim.api.nvim_get_namespaces = orig_get_ns
+			if not ok then
+				error(err, 0)
+			end
+		end
+	end
 }
 
 addPlugin {


### PR DESCRIPTION
## Summary

`:InspectExtmarks` (from `delphinus/inspect-extmarks.nvim`) crashed whenever the cursor line had an
extmark in an **anonymous** namespace. `vim.api.nvim_get_namespaces()` omits anonymous namespaces,
so the plugin resolved `ns_name` to `nil`, which broke it in two places:

- `inspect-extmarks.lua:68` — the sort `a.ns_name < b.ns_name` (`nil < …`) with 2+ marks at a
  position.
- `inspect-extmarks.lua:141` — `nvim_echo` rejecting a `{ nil, "Title" }` chunk ("Invalid chunk:
  expected Array with 1 or 2 Strings").

This wraps the plugin's `inspect()` in `neovim/init.lua` and, for the duration of one call,
temporarily names every anonymous namespace present on the cursor row (`<anonymous N>`), so
`ns_name` is always a string. Both crash sites are fixed at the source of the `nil`. The previous
attempt (#75) patched only `nvim_echo` and could not reach the line-68 sort; it was reverted.

## Testing

Validated headlessly against the **real** installed plugin and the **real** worktree config:

- Before (unpatched): single anonymous mark → `...:141: Invalid chunk`; two anonymous marks →
  `...:68: attempt to compare two nil values`.
- After: single-anon, two-anon-sort, named+anon, and named-only all pass with no error; output
  renders `<anonymous N>` entries correctly; `nvim_get_namespaces` is restored after each call (no
  synthetic-name leak). Stable over repeated runs.
- Manually verified interactively on a real buffer (multiple anonymous-namespace extmarks from live
  plugins) — entries print cleanly, no error in `:messages`.

Only `neovim/init.lua` changes (+45/-1). The wrapper runs only on explicit `:InspectExtmarks`
invocation, so there is no startup or edit-time cost.

Closes #54
